### PR TITLE
Fixing two defects with Images plugin Title in links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,10 +9,11 @@ config/database.yml
 config/email.yml
 
 # Don't Include Rails
-vendor/rails
+#vendor/rails
 
 # Master Graphics
 *_master.png
+*.ai
 
 # Only Include Public Themes
 !public/themes/white_square

--- a/.gitignore.save
+++ b/.gitignore.save
@@ -1,0 +1,7 @@
+# Rails
+.bundle
+db/*.sqlite3
+*.log
+tmp/**/*
+config/database.yml
+config/databaseyml

--- a/app/views/pages/tinymce_images.html.erb
+++ b/app/views/pages/tinymce_images.html.erb
@@ -45,7 +45,7 @@
 			</div>
 			<div id="Upload">								   
 			  <% if @item %>
-	   			<%= form_tag ({:action => 'create', :controller => "plugin_#{@plugin.title}s", :id => @item.id, :tinymce => "true"} , :multipart => true) %>			 
+	   			<%= form_tag ({:action => 'create', :controller => "plugin_items", :id => @item.id, :tinymce => "true"} , :multipart => true) %>			 
 			  <% else %>			
 				<%= form_tag ({:action => 'upload_image', :controller => "pages"} , :multipart => true) %>
 			  <% end %>				

--- a/app/views/pages/tinymce_images.html.erb
+++ b/app/views/pages/tinymce_images.html.erb
@@ -45,7 +45,7 @@
 			</div>
 			<div id="Upload">								   
 			  <% if @item %>
-	   			<%= form_tag ({:action => 'create', :controller => "plugin_items", :id => @item.id, :tinymce => "true"} , :multipart => true) %>			 
+	   			<%= form_tag ({:action => 'create', :controller => "plugin_images", :id => @item.id, :tinymce => "true"} , :multipart => true) %>			 
 			  <% else %>			
 				<%= form_tag ({:action => 'upload_image', :controller => "pages"} , :multipart => true) %>
 			  <% end %>				

--- a/app/views/plugin_images/_view.rhtml
+++ b/app/views/plugin_images/_view.rhtml
@@ -67,7 +67,7 @@
 								   	<% if image.id == images[0].id %>									
 										<%#= "<img src=\"/themes/#{@setting[:theme]}/images/icons/success.png\" class=\"icon\"> " %> <b>Main Image</b>
 									<% else %>
-								   		<%= link_to "Set as Main #{plugin.title}", { :action => 'change_main_image', :controller => "plugin_#{plugin.title}s", :id => item.id, :image_id => image.id} %>									
+								   		<%= link_to "Set as Main #{plugin.title}", { :action => 'change_main_image', :controller => "plugin_images", :id => item.id, :image_id => image.id} %>									
 									<% end %>
 									</div>								
 								<% end %>															


### PR DESCRIPTION
With custom Images plugin Title user won't be able to
- Upload an image
- Set image as main

Because plugin Title is used in link, while shouldn't.

Totally 3 commits. (One extra commit fixing my typo :( )
