### PR TITLE
Partly implementation of ticket #523

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ gem "mysql2"
 gem 'sqlite3'
 gem 'dynamic_form'
 gem 'thin'
+gem "friendly_id", "~> 4.0.1"
 
 group :development do
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,6 +91,7 @@ GEM
       nokogiri (>= 1.4.4)
       ruby-hmac
     formatador (0.2.1)
+    friendly_id (4.0.1)
     hashie (1.2.0)
     hike (1.2.1)
     humanizer (2.4.3)
@@ -218,6 +219,7 @@ DEPENDENCIES
   dynamic_form
   factory_girl_rails
   fog
+  friendly_id (~> 4.0.1)
   humanizer (= 2.4.3)
   i18n
   jquery-rails

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -2,6 +2,10 @@ class Category < ActiveRecord::Base
   include ActionView::Helpers::TextHelper # include text helper for truncate and other options
   has_ancestry if Category.table_exists? && column_names.include?("ancestry")
 
+  if Category.table_exists? && Category.column_names.include?("slug")
+    extend FriendlyId
+    friendly_id :name, :use => :slugged
+  end
   
   has_many :items, :dependent => :destroy
   has_many :categories, :dependent => :destroy
@@ -17,10 +21,6 @@ class Category < ActiveRecord::Base
     name
   end
   
-  def to_param # make custom parameter generator for seo urls
-    "#{id}-#{name.parameterize}"
-  end
-    
   def self.get_parent_categories # Category.get_parent_categories
     return find(:all, :conditions =>["category_id = 0"], :order => "name ASC")         
   end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,4 +1,9 @@
 class Item < ActiveRecord::Base
+  if Item.table_exists? && Item.column_names.include?("slug")
+    extend FriendlyId
+    friendly_id :name, :use => :slugged
+  end
+
   has_one :item_statistic 
   belongs_to :user
   belongs_to :category
@@ -34,11 +39,6 @@ class Item < ActiveRecord::Base
   scope :popular, order("recent_views DESC")
   scope :listed, where(:listed => true)
  
-  def to_param # make custom parameter generator for seo urls, to use: pass actual object(not id) into id ie: :id => object
-    # this is also backwards compatible with regular integer id lookups, since .to_i gets only contiguous numbers, ie: "4-some-string-here".to_i # => 4    
-    "#{id}-#{name.parameterize}" 
-  end
-  
   def to_s
     name
   end

--- a/app/models/page.rb
+++ b/app/models/page.rb
@@ -1,6 +1,11 @@
 class Page < ActiveRecord::Base
   has_ancestry if Page.table_exists? && column_names.include?("ancestry")
 
+  if Page.table_exists? && Page.column_names.include?("slug")
+    extend FriendlyId
+    friendly_id :title, :use => :slugged
+  end
+
   has_many :pages
   has_many :plugin_comments, :dependent => :destroy, :as => :record
   belongs_to :page
@@ -58,11 +63,6 @@ class Page < ActiveRecord::Base
   # return group ids as ints 
   def group_ids
     self["group_ids"].collect{|o|o.to_i}
-  end
-
-  def to_param # make custom parameter generator for seo urls, to use: pass actual object(not id) into id ie: :id => object
-    # this is also backwards compatible with regular integer id lookups, since .to_i gets only contiguous numbers, ie: "4-some-string-here".to_i # => 4    
-    "#{id}-#{title.parameterize}" 
   end
   
   def model_name(count = 1) # return human name of instance

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,11 @@
 class User < ActiveRecord::Base
   require 'digest/sha2'
 
+  if User.table_exists? && User.column_names.include?("slug")
+    extend FriendlyId
+    friendly_id :username, :use => :slugged
+  end
+
   make_voter
   mount_uploader :avatar, ::AvatarUploader
 
@@ -92,11 +97,6 @@ class User < ActiveRecord::Base
              :order => 'username'
   end
 
-  def to_param # make custom parameter generator for seo urls, to use: pass actual object(not id) into id ie: :id => object
-    # this is also backwards compatible with id lookups, since .to_i gets only contiguous numbers, ie: "4-some-string-here".to_i # => 4    
-    "#{id}-#{username.parameterize}" 
-  end
-  
   def to_s
     self.username
   end

--- a/db/migrate/005_create_categories.rb
+++ b/db/migrate/005_create_categories.rb
@@ -10,8 +10,6 @@ class CreateCategories < ActiveRecord::Migration
      t.column :updated_at, :datetime
     end
 
-	# Create Categories
-	Category.create(:name => I18n.t('seeds.category.uncategorized.name'), :category_id => 0, :description => I18n.t('seeds.category.uncategorized.description'))    
   end
 
   def self.down

--- a/db/migrate/20090724224343_create_pages.rb
+++ b/db/migrate/20090724224343_create_pages.rb
@@ -21,53 +21,6 @@ class CreatePages < ActiveRecord::Migration
       t.column :redirect_url, :string, :default => nil # if they want to redirect this to another url
       t.timestamps
     end
-
-	# Create  Pages
-	pages = Hash.new
-	title = Setting.get_setting("title")
-	Page.create(:title => I18n.t('seeds.page.banner_top.title'), :description => I18n.t('seeds.page.banner_top.description'), :page_type => "system", :content => I18n.t('seeds.page.banner_top.content'))
-	Page.create(:title => I18n.t('seeds.page.banner_bottom.title'), :description => I18n.t('seeds.page.banner_bottom.description'), :page_type => "system", :content => I18n.t('seeds.page.banner_bottom.content'))
-	#Page.create(:title => I18n.t('seeds.page.terms_of_service.title'), :description => I18n.t('seeds.page.terms_of_service.description'), :page_type => "system", :content => I18n.t('seeds.page.terms_of_service.content'))
-	# Add a new page that will show when a user is creating a new item.
-	Page.create(:title => I18n.t('seeds.page.new_item.title'), :description => I18n.t('seeds.page.new_item.description'), :page_type => "system", :content => I18n.t('seeds.page.new_item.content'))
-	# Create Email Footer Page
-	Page.create(:title => I18n.t('seeds.page.email_footer.title'), :description => I18n.t('seeds.page.email_footer.description'), :page_type => "system", :content => I18n.t('seeds.page.email_footer.content'))
-	# Create Homepage Sidebar Page
-	Page.create(:title => I18n.t('seeds.page.home_page_sidebar.title'), :description => I18n.t('seeds.page.home_page_sidebar.description'), :page_type => "system", :content => I18n.t('seeds.page.home_page_sidebar.content'))
-	Page.create(:title => I18n.t('seeds.page.website_top.title'), :description => I18n.t('seeds.page.website_top.description'), :page_type => "system", :content => I18n.t('seeds.page.website_top.content'))
-	Page.create(:title => I18n.t('seeds.page.website_bottom.title'), :description => I18n.t('seeds.page.website_bottom.description'), :page_type => "system", :content => I18n.t('seeds.page.website_bottom.content'))
-	Page.create(:title => I18n.t('seeds.page.category_column.title'), :description => I18n.t('seeds.page.category_column.description'), :page_type => "system", :content => I18n.t('seeds.page.category_column.content'))
-	
-	pages[:home] = Page.new(:title => I18n.t('seeds.page.home.title'), :description => I18n.t('seeds.page.home.description'), :page_type => "public", :content => I18n.t('seeds.page.home.content'))
-	pages[:home].name = "home"
-	pages[:home].locked = true
-	pages[:home].deletable = false
-	pages[:home].save
-	
-	pages[:items] = Page.new(:title => I18n.t('seeds.page.items.title'), :description => I18n.t('seeds.page.items.description'), :page_type => "public", :content => I18n.t('seeds.page.items.content'))
-	pages[:items].name = "items"
-	pages[:items].locked = true
-	pages[:items].title_editable = false
-	pages[:items].deletable = false
-	pages[:items].save 
-	
-	pages[:blog] = Page.new(:title => I18n.t('seeds.page.blog.title'), :description => I18n.t('seeds.page.blog.description'), :page_type => "public", :content => I18n.t('seeds.page.blog.content'))
-	pages[:blog].name = "blog"
-	pages[:blog].locked = true
-	pages[:blog].deletable = false
-	pages[:blog].save
-	
-	pages[:tos] = Page.new(:title => I18n.t('seeds.page.terms_of_service.title'), :description => I18n.t('seeds.page.terms_of_service.description'), :page_type => "public", :content => I18n.t('seeds.page.terms_of_service.content'))
-	pages[:tos].deletable = false
-	pages[:tos].name = "terms_of_service"
-	pages[:tos].display_in_menu = false
-	pages[:tos].locked = true
-	pages[:tos].save
-	
-	pages[:contact_us] = Page.new(:name => "contact_us", :title => I18n.t('seeds.page.contact_us.title'), :description => I18n.t('seeds.page.contact_us.description'), :page_type => "public", :content => I18n.t('seeds.page.contact_us.content'))
-	pages[:contact_us].locked = true
-	pages[:contact_us].deletable = false
-	pages[:contact_us].save   
   end
 
   def self.down

--- a/db/migrate/20120125042703_make_items_page_title_editable.rb
+++ b/db/migrate/20120125042703_make_items_page_title_editable.rb
@@ -1,9 +1,15 @@
 class MakeItemsPageTitleEditable < ActiveRecord::Migration
   def up
-    Page.find_by_name("items").update_attribute(:title_editable, true)
+    items_page = Page.find_by_name("items")
+    if !items_page.nil?
+      items_page.update_attribute(:title_editable, true)
+    end
   end
 
   def down
-    Page.find_by_name("items").update_attribute(:title_editable, false)
+    items_page = Page.find_by_name("items")
+    if !items_page.nil?
+      items_page.update_attribute(:title_editable, false)
+    end
   end
 end

--- a/db/migrate/20120305231302_add_slug_to_categories.rb
+++ b/db/migrate/20120305231302_add_slug_to_categories.rb
@@ -1,0 +1,6 @@
+class AddSlugToCategories < ActiveRecord::Migration
+  def change
+    add_column :categories, :slug, :string
+    add_index :categories, :slug, :unique => true
+  end
+end

--- a/db/migrate/20120310103817_add_slug_to_items.rb
+++ b/db/migrate/20120310103817_add_slug_to_items.rb
@@ -1,0 +1,6 @@
+class AddSlugToItems < ActiveRecord::Migration
+  def change
+    add_column :items, :slug, :string
+    add_index :items, :slug, :unique => true
+  end
+end

--- a/db/migrate/20120310123336_add_slug_to_pages.rb
+++ b/db/migrate/20120310123336_add_slug_to_pages.rb
@@ -1,0 +1,6 @@
+class AddSlugToPages < ActiveRecord::Migration
+  def change
+    add_column :pages, :slug, :string
+    add_index :pages, :slug, :unique => true
+  end
+end

--- a/db/migrate/20120310160046_add_slug_to_users.rb
+++ b/db/migrate/20120310160046_add_slug_to_users.rb
@@ -1,0 +1,6 @@
+class AddSlugToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :slug, :string
+    add_index :users, :slug, :unique => true
+  end
+end

--- a/db/migrate/20120310182815_resave_objects_to_generate_slugs.rb
+++ b/db/migrate/20120310182815_resave_objects_to_generate_slugs.rb
@@ -1,0 +1,11 @@
+class ResaveObjectsToGenerateSlugs < ActiveRecord::Migration
+  def up
+    # This migration is needed for users who upgrade Opal from v0.8.1 to v0.8.2
+    # Existing objects need to have slugs for Friendly URLs 
+    # Resaving existing objects (without any changes) will generate slugs for them
+    Category.find_each(&:save)
+    Item.find_each(&:save)
+    Page.find_each(&:save)
+    User.find_each(&:save)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,14 +11,14 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20120306044926) do
+ActiveRecord::Schema.define(:version => 20120305231302) do
 
   create_table "authentications", :force => true do |t|
     t.integer  "user_id"
     t.string   "provider"
     t.string   "uid"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", :null => false
+    t.datetime "updated_at", :null => false
   end
 
   create_table "categories", :force => true do |t|
@@ -29,9 +29,11 @@ ActiveRecord::Schema.define(:version => 20120306044926) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "ancestry"
+    t.string   "slug"
   end
 
   add_index "categories", ["ancestry"], :name => "index_categories_on_ancestry"
+  add_index "categories", ["slug"], :name => "index_categories_on_slug", :unique => true
 
   create_table "group_plugin_permissions", :force => true do |t|
     t.integer  "group_id"
@@ -41,16 +43,16 @@ ActiveRecord::Schema.define(:version => 20120306044926) do
     t.string   "can_update",        :limit => 1, :default => "0"
     t.string   "can_delete",        :limit => 1, :default => "0"
     t.string   "requires_approval", :limit => 1, :default => "0"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                                      :null => false
+    t.datetime "updated_at",                                      :null => false
   end
 
   create_table "groups", :force => true do |t|
     t.string   "name"
     t.string   "description"
     t.string   "is_deletable", :limit => 1, :default => "1"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                                 :null => false
+    t.datetime "updated_at",                                 :null => false
   end
 
   add_index "groups", ["name"], :name => "index_groups_on_name"
@@ -91,8 +93,8 @@ ActiveRecord::Schema.define(:version => 20120306044926) do
     t.integer  "item_id"
     t.string   "log"
     t.string   "log_type"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",      :null => false
+    t.datetime "updated_at",      :null => false
     t.string   "target_type"
     t.integer  "target_id"
     t.string   "ip"
@@ -106,8 +108,8 @@ ActiveRecord::Schema.define(:version => 20120306044926) do
     t.string   "anonymous_email"
     t.string   "anonymous_name"
     t.string   "is_approved",     :limit => 1, :default => "0"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                                    :null => false
+    t.datetime "updated_at",                                    :null => false
   end
 
   create_table "pages", :force => true do |t|
@@ -128,8 +130,8 @@ ActiveRecord::Schema.define(:version => 20120306044926) do
     t.boolean  "display_in_menu",      :default => true
     t.boolean  "redirect",             :default => false
     t.string   "redirect_url"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                                 :null => false
+    t.datetime "updated_at",                                 :null => false
     t.string   "ancestry"
     t.boolean  "display_children",     :default => true
     t.boolean  "group_access_only",    :default => false
@@ -138,6 +140,8 @@ ActiveRecord::Schema.define(:version => 20120306044926) do
   end
 
   add_index "pages", ["ancestry"], :name => "index_pages_on_ancestry"
+  add_index "pages", ["name"], :name => "index_pages_on_name"
+  add_index "pages", ["title"], :name => "index_pages_on_title"
 
   create_table "plugin_comments", :force => true do |t|
     t.integer  "user_id"
@@ -173,8 +177,8 @@ ActiveRecord::Schema.define(:version => 20120306044926) do
     t.text     "post"
     t.string   "is_sticky",            :limit => 1, :default => "1"
     t.string   "is_enabled",           :limit => 1, :default => "0"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                                         :null => false
+    t.datetime "updated_at",                                         :null => false
   end
 
   create_table "plugin_discussions", :force => true do |t|
@@ -184,8 +188,8 @@ ActiveRecord::Schema.define(:version => 20120306044926) do
     t.string   "is_sticky",   :limit => 1, :default => "0"
     t.string   "is_approved", :limit => 1, :default => "0"
     t.string   "is_closed",   :limit => 1, :default => "0"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                                :null => false
+    t.datetime "updated_at",                                :null => false
     t.string   "record_type"
     t.integer  "record_id"
   end
@@ -195,8 +199,8 @@ ActiveRecord::Schema.define(:version => 20120306044926) do
     t.integer  "user_id"
     t.string   "value"
     t.string   "description"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",        :null => false
+    t.datetime "updated_at",        :null => false
   end
 
   create_table "plugin_feature_values", :force => true do |t|
@@ -269,8 +273,8 @@ ActiveRecord::Schema.define(:version => 20120306044926) do
     t.integer  "plugin_review_id"
     t.integer  "user_id"
     t.integer  "score",            :default => 0
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                      :null => false
+    t.datetime "updated_at",                      :null => false
   end
 
   create_table "plugin_reviews", :force => true do |t|
@@ -295,8 +299,8 @@ ActiveRecord::Schema.define(:version => 20120306044926) do
     t.string   "setting_type"
     t.string   "value"
     t.string   "item_type"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",   :null => false
+    t.datetime "updated_at",   :null => false
     t.string   "options"
   end
 
@@ -319,8 +323,8 @@ ActiveRecord::Schema.define(:version => 20120306044926) do
     t.text     "description"
     t.text     "code"
     t.string   "is_approved", :limit => 1, :default => "0"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                                :null => false
+    t.datetime "updated_at",                                :null => false
     t.string   "record_type"
     t.integer  "record_id"
     t.string   "video"
@@ -329,8 +333,8 @@ ActiveRecord::Schema.define(:version => 20120306044926) do
   create_table "plugins", :force => true do |t|
     t.string   "name"
     t.integer  "order_number",              :default => 0
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                                 :null => false
+    t.datetime "updated_at",                                 :null => false
     t.string   "is_enabled",   :limit => 1, :default => "1"
     t.string   "is_builtin",   :limit => 1, :default => "0"
   end
@@ -340,8 +344,8 @@ ActiveRecord::Schema.define(:version => 20120306044926) do
   create_table "sessions", :force => true do |t|
     t.string   "session_id", :null => false
     t.text     "data"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", :null => false
+    t.datetime "updated_at", :null => false
   end
 
   add_index "sessions", ["session_id"], :name => "index_sessions_on_session_id"
@@ -362,8 +366,8 @@ ActiveRecord::Schema.define(:version => 20120306044926) do
   create_table "simple_captcha_data", :force => true do |t|
     t.string   "key",        :limit => 40
     t.string   "value",      :limit => 6
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",               :null => false
+    t.datetime "updated_at",               :null => false
   end
 
   add_index "simple_captcha_data", ["key"], :name => "idx_key"
@@ -405,8 +409,8 @@ ActiveRecord::Schema.define(:version => 20120306044926) do
     t.string   "ip"
     t.datetime "verification_date"
     t.string   "is_verified",       :limit => 1, :default => "0"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                                                     :null => false
+    t.datetime "updated_at",                                                     :null => false
   end
 
   create_table "users", :force => true do |t|
@@ -448,8 +452,8 @@ ActiveRecord::Schema.define(:version => 20120306044926) do
     t.string   "voter_type"
     t.integer  "voter_id"
     t.boolean  "up_vote",       :null => false
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",    :null => false
+    t.datetime "updated_at",    :null => false
   end
 
   add_index "votings", ["voteable_type", "voteable_id", "voter_type", "voter_id"], :name => "unique_voters", :unique => true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20120310160046) do
+ActiveRecord::Schema.define(:version => 20120310182815) do
 
   create_table "authentications", :force => true do |t|
     t.integer  "user_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20120310103817) do
+ActiveRecord::Schema.define(:version => 20120310123336) do
 
   create_table "authentications", :force => true do |t|
     t.integer  "user_id"
@@ -139,10 +139,12 @@ ActiveRecord::Schema.define(:version => 20120310103817) do
     t.boolean  "display_children",     :default => true
     t.boolean  "group_access_only",    :default => false
     t.string   "group_ids"
+    t.string   "slug"
   end
 
   add_index "pages", ["ancestry"], :name => "index_pages_on_ancestry"
   add_index "pages", ["name"], :name => "index_pages_on_name"
+  add_index "pages", ["slug"], :name => "index_pages_on_slug", :unique => true
   add_index "pages", ["title"], :name => "index_pages_on_title"
 
   create_table "plugin_comments", :force => true do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20120305231302) do
+ActiveRecord::Schema.define(:version => 20120310103817) do
 
   create_table "authentications", :force => true do |t|
     t.integer  "user_id"
@@ -86,7 +86,10 @@ ActiveRecord::Schema.define(:version => 20120305231302) do
     t.string   "preview_type"
     t.integer  "preview_id"
     t.boolean  "listed",                    :default => true
+    t.string   "slug"
   end
+
+  add_index "items", ["slug"], :name => "index_items_on_slug", :unique => true
 
   create_table "logs", :force => true do |t|
     t.integer  "user_id"
@@ -136,7 +139,6 @@ ActiveRecord::Schema.define(:version => 20120305231302) do
     t.boolean  "display_children",     :default => true
     t.boolean  "group_access_only",    :default => false
     t.string   "group_ids"
-    t.text     "side"
   end
 
   add_index "pages", ["ancestry"], :name => "index_pages_on_ancestry"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20120310123336) do
+ActiveRecord::Schema.define(:version => 20120310160046) do
 
   create_table "authentications", :force => true do |t|
     t.integer  "user_id"
@@ -443,11 +443,13 @@ ActiveRecord::Schema.define(:version => 20120310123336) do
     t.string   "current_login_ip"
     t.string   "salt"
     t.string   "avatar"
+    t.string   "slug"
   end
 
   add_index "users", ["email"], :name => "index_users_on_email"
   add_index "users", ["last_request_at"], :name => "index_users_on_last_request_at"
   add_index "users", ["persistence_token"], :name => "index_users_on_persistence_token"
+  add_index "users", ["slug"], :name => "index_users_on_slug", :unique => true
   add_index "users", ["username"], :name => "index_users_on_username"
 
   create_table "votings", :force => true do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,6 +9,9 @@ I18n.locale = ENV['LOCALE'].nil? ? "en" : ENV['LOCALE']  # Define locale
 @admin.locale = I18n.locale.to_s
 @admin.save
 
+# Create Categories
+Category.create(:name => I18n.t('seeds.category.uncategorized.name'), :category_id => 0, :description => I18n.t('seeds.category.uncategorized.description'))    
+
 puts "\n" + I18n.t("notice.item_install_success", :item => I18n.t("name")) + "\n"
 puts I18n.t("label.login_as", :username => I18n.t('seeds.user.admin.username'), :password => I18n.t('seeds.user.admin.password'))
 Log.create(:log => I18n.t("notice.item_install_success", :item => I18n.t("name")), :log_type => "system") # Log Install

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,6 +1,53 @@
 # This file creates required data for new installations. 
 I18n.locale = ENV['LOCALE'].nil? ? "en" : ENV['LOCALE']  # Define locale 
 
+# Create  Pages
+pages = Hash.new
+title = Setting.get_setting("title")
+Page.create(:title => I18n.t('seeds.page.banner_top.title'), :description => I18n.t('seeds.page.banner_top.description'), :page_type => "system", :content => I18n.t('seeds.page.banner_top.content'))
+Page.create(:title => I18n.t('seeds.page.banner_bottom.title'), :description => I18n.t('seeds.page.banner_bottom.description'), :page_type => "system", :content => I18n.t('seeds.page.banner_bottom.content'))
+#Page.create(:title => I18n.t('seeds.page.terms_of_service.title'), :description => I18n.t('seeds.page.terms_of_service.description'), :page_type => "system", :content => I18n.t('seeds.page.terms_of_service.content'))
+# Add a new page that will show when a user is creating a new item.
+Page.create(:title => I18n.t('seeds.page.new_item.title'), :description => I18n.t('seeds.page.new_item.description'), :page_type => "system", :content => I18n.t('seeds.page.new_item.content'))
+# Create Email Footer Page
+Page.create(:title => I18n.t('seeds.page.email_footer.title'), :description => I18n.t('seeds.page.email_footer.description'), :page_type => "system", :content => I18n.t('seeds.page.email_footer.content'))
+# Create Homepage Sidebar Page
+Page.create(:title => I18n.t('seeds.page.home_page_sidebar.title'), :description => I18n.t('seeds.page.home_page_sidebar.description'), :page_type => "system", :content => I18n.t('seeds.page.home_page_sidebar.content'))
+Page.create(:title => I18n.t('seeds.page.website_top.title'), :description => I18n.t('seeds.page.website_top.description'), :page_type => "system", :content => I18n.t('seeds.page.website_top.content'))
+Page.create(:title => I18n.t('seeds.page.website_bottom.title'), :description => I18n.t('seeds.page.website_bottom.description'), :page_type => "system", :content => I18n.t('seeds.page.website_bottom.content'))
+Page.create(:title => I18n.t('seeds.page.category_column.title'), :description => I18n.t('seeds.page.category_column.description'), :page_type => "system", :content => I18n.t('seeds.page.category_column.content'))
+
+pages[:home] = Page.new(:title => I18n.t('seeds.page.home.title'), :description => I18n.t('seeds.page.home.description'), :page_type => "public", :content => I18n.t('seeds.page.home.content'))
+pages[:home].name = "home"
+pages[:home].locked = true
+pages[:home].deletable = false
+pages[:home].save
+
+pages[:items] = Page.new(:title => I18n.t('seeds.page.items.title'), :description => I18n.t('seeds.page.items.description'), :page_type => "public", :content => I18n.t('seeds.page.items.content'))
+pages[:items].name = "items"
+pages[:items].locked = true
+pages[:items].title_editable = true
+pages[:items].deletable = false
+pages[:items].save 
+
+pages[:blog] = Page.new(:title => I18n.t('seeds.page.blog.title'), :description => I18n.t('seeds.page.blog.description'), :page_type => "public", :content => I18n.t('seeds.page.blog.content'))
+pages[:blog].name = "blog"
+pages[:blog].locked = true
+pages[:blog].deletable = false
+pages[:blog].save
+
+pages[:tos] = Page.new(:title => I18n.t('seeds.page.terms_of_service.title'), :description => I18n.t('seeds.page.terms_of_service.description'), :page_type => "public", :content => I18n.t('seeds.page.terms_of_service.content'))
+pages[:tos].deletable = false
+pages[:tos].name = "terms_of_service"
+pages[:tos].display_in_menu = false
+pages[:tos].locked = true
+pages[:tos].save
+
+pages[:contact_us] = Page.new(:name => "contact_us", :title => I18n.t('seeds.page.contact_us.title'), :description => I18n.t('seeds.page.contact_us.description'), :page_type => "public", :content => I18n.t('seeds.page.contact_us.content'))
+pages[:contact_us].locked = true
+pages[:contact_us].deletable = false
+pages[:contact_us].save   
+
 # Create Default Admin Account
 @admin = User.new(:first_name => I18n.t('seeds.user.admin.first_name'), :last_name => I18n.t('seeds.user.admin.last_name'), :username => I18n.t('seeds.user.admin.username'), :password => I18n.t('seeds.user.admin.password'), :password_confirmation => I18n.t('seeds.user.admin.password'), :is_admin => "1", :email => I18n.t('seeds.user.admin.email'))
 @admin.group_id = Group.admin.id


### PR DESCRIPTION
Details of this can be found in tracker - http://dev.hulihanapplications.com/issues/show/523
Quote from the ticket:

Details of implementation:
-   Gem FriendlyId was used as suggested above
-   Following models was affected:
  *\* Categories
  *\* Items
  *\* Pages
  *\* Users
- For each type of item column "slug" was added (in separate migrations)
- One more migration for resaving of existing objects was added
- Creation of objects was moved from migrations to seeds. Additional ticket #542 was added for completion of this (probably in other milestone)
